### PR TITLE
Brewing Methods functionality

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,6 +12,8 @@ import Methods from './views/Methods';
 import Recipes from './views/Recipes';
 import AddCoffee from './forms/AddCoffee';
 import EditCoffee from './forms/EditCoffee';
+import AddMethod from './forms/AddMethod';
+import EditMethod from './forms/EditMethod';
 
 function App() {
 
@@ -30,6 +32,8 @@ function App() {
               <PrivateRoute exact path='/recipes' component={Recipes} />
               <PrivateRoute path='/coffees/new' component={AddCoffee} />
               <PrivateRoute path='/coffees/edit/:coffeeId' component={EditCoffee} />
+              <PrivateRoute path='/methods/new' component={AddMethod} />
+              <PrivateRoute path='/methods/edit/:methodId' component={EditMethod} />
             </Switch>
         </Router>
       </Container>

--- a/src/forms/AddCoffee.js
+++ b/src/forms/AddCoffee.js
@@ -43,6 +43,10 @@ const AddCoffee = ({ currentUser }) => {
             });
     };
 
+    const cancelClickHandler = () => {
+        history.push('/coffees');
+    };
+
     return (
         <>
             <h2>Add Coffee</h2>
@@ -102,6 +106,7 @@ const AddCoffee = ({ currentUser }) => {
                 >
                 </TextField>
                 <Button color='primary' type='submit'>Add Coffee</Button>
+                <Button color='secondary' onClick={cancelClickHandler}>Cancel</Button>
             </form>
         </>
     );

--- a/src/forms/AddMethod.js
+++ b/src/forms/AddMethod.js
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+import apiRequest from '../utils/apiRequest';
+import { TextField, Button } from '@material-ui/core';
+import { useHistory } from 'react-router-dom';
+
+const AddMethod = ({ currentUser }) => {
+
+    const [ method, setMethod ] = useState({
+        name: ''
+    });
+
+    const history = useHistory();
+
+    const onChangeHandler = e => {
+        setMethod({
+            ...method,
+            [e.target.name]: e.target.value
+        });
+    };
+
+    const onSubmitHandler = e => {
+        e.preventDefault();
+        apiRequest(currentUser.token)
+            .post(`/users/${currentUser.id}/methods`, { ...method, user_id: currentUser.id })
+            .then(() => {
+                setMethod({
+                    name: ''
+                });
+                history.push('/methods');
+            })
+            .catch(() => {
+                history.push('/login');
+            });
+    };
+
+    const cancelClickHandler = () => {
+        history.push('/methods');
+    };
+
+    return (
+        <>
+            <h2>Add Method</h2>
+            <form onSubmit={onSubmitHandler}>
+                <TextField 
+                    margin='normal'
+                    label='Name'
+                    name='name'
+                    onChange={onChangeHandler}
+                    value={method.name}
+                    fullWidth
+                >
+                </TextField>
+                <Button color='primary' type='submit'>Add Method</Button>
+                <Button color='secondary' onClick={cancelClickHandler}>Cancel</Button>
+            </form>
+        </>
+    );
+};
+
+export default AddMethod;

--- a/src/forms/EditCoffee.js
+++ b/src/forms/EditCoffee.js
@@ -63,6 +63,10 @@ const EditCoffee = ({ currentUser }) => {
             });
     };
 
+    const cancelClickHandler = () => {
+        history.push('/coffees');
+    };
+
     return (
         <>
             <h2>Edit Coffee</h2>
@@ -122,6 +126,7 @@ const EditCoffee = ({ currentUser }) => {
                 >
                 </TextField>
                 <Button color='primary' type='submit'>Update Coffee</Button>
+                <Button color='secondary' onClick={cancelClickHandler}>Cancel</Button>
             </form>
         </>
     );

--- a/src/forms/EditMethod.js
+++ b/src/forms/EditMethod.js
@@ -1,0 +1,74 @@
+import React, { useState, useEffect } from 'react';
+import { useHistory, useParams } from 'react-router-dom';
+import apiRequest from '../utils/apiRequest';
+import { TextField, Button } from '@material-ui/core';
+
+const EditMethod = ({ currentUser }) => {
+
+    const { methodId } = useParams();
+    
+    const [ method, setMethod ] = useState({
+        name: ''
+    });
+
+    const history = useHistory();
+
+    useEffect(() => {
+        apiRequest(currentUser.token)
+            .get(`/users/${currentUser.id}/methods/${methodId}`)
+            .then(res => {
+                setMethod({
+                    name: res.data.name
+                })
+            })
+            .catch(() => {
+                history.push('/login');
+            });
+    }, [methodId, currentUser.id, currentUser.token, history]);
+
+    const onChangeHandler = e => {
+        setMethod({
+            [e.target.name]: e.target.value
+        });
+    };
+
+    const onSubmitHandler = e => {
+        e.preventDefault();
+        apiRequest(currentUser.token)
+            .put(`/users/${currentUser.id}/methods/${methodId}`, { ...method, user_id: currentUser.id })
+            .then(() => {
+                setMethod({
+                    name: ''
+                });
+                history.push('/methods');
+            })
+            .catch(err => {
+                history.push('/login');
+            });
+    };
+
+    const cancelClickHandler = () => {
+        history.push('/methods');
+    };
+
+    return (
+        <>
+            <h2>Edit Method</h2>
+            <form onSubmit={onSubmitHandler}>
+                <TextField 
+                    margin='normal'
+                    label='Name'
+                    name='name'
+                    onChange={onChangeHandler}
+                    value={method.name}
+                    fullWidth
+                >
+                </TextField>
+                <Button color='primary' type='submit'>Update Method</Button>
+                <Button color='secondary' onClick={cancelClickHandler}>Cancel</Button>
+            </form>
+        </>
+    );
+};
+
+export default EditMethod;

--- a/src/views/Methods.js
+++ b/src/views/Methods.js
@@ -1,10 +1,77 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import apiRequest from '../utils/apiRequest';
+import { Grid, Card, CardContent, CardActions, Button } from '@material-ui/core'
+import { Link, useHistory } from 'react-router-dom';
 
 const Methods = ({ currentUser }) => {
+
+  const [methods, setMethods ] = useState(null);
+  const history = useHistory();
+
+  useEffect(() => {
+    apiRequest(currentUser.token)
+      .get(`/users/${currentUser.id}/methods`)
+      .then(res => {
+        setMethods(res.data)
+      })
+      .catch(() => {
+        history.push('/login');
+      });
+  }, [setMethods, currentUser.token, currentUser.id, history]);
+
+  const deleteHandler = methodId => {
+    apiRequest(currentUser.token)
+      .delete(`/users/${currentUser.id}/methods/${methodId}`)
+      .then(() => {
+        const updatedMethods = methods.filter(method => method.id !== methodId);
+        setMethods(updatedMethods);
+      })
+      .catch(() => {
+        history.push('/login');
+      });
+  };
+
+  if (!methods) {
+    return (
+      <>
+        <h1>All Methods</h1>
+        <h2>...Loading</h2>
+      </>
+    );
+  }
+
   return (
-    <div>
-      <h2>All Methods</h2>
-    </div>
+    <>
+      <Grid container justify='space-between' alignItems='center'>
+        <Grid item xs={4}>
+        <h2>All Methods</h2>
+        </Grid>
+        <Grid item xs={3}>
+          <Link to='/methods/new'>
+            <Button color='primary'>Add New Method</Button>
+          </Link>
+        </Grid>
+      </Grid>
+      <Grid container spacing={3}>
+        {
+          methods.length === 0 ?
+          <h3>Add methods to get started.</h3>
+          : methods.map(method => {
+            return <Grid item xs={12} key={method.id}>
+                    <Card>
+                      <CardContent>
+                        <p><strong>Name:</strong> {method.name}</p>
+                      </CardContent>
+                      <CardActions>
+                        <Link to={`/methods/edit/${method.id}`}><Button>Edit</Button></Link>
+                        <Button color="secondary" onClick={() => deleteHandler(method.id)}>Delete</Button>
+                      </CardActions>
+                    </Card>
+                   </Grid>
+          })
+        }
+      </Grid>
+    </>
   );
 }
 


### PR DESCRIPTION
Closes #12 

Add listing of coffee brewing methods at `/methods`
There is a `Add New Method` button to go to a form for adding a new one
There are `Edit` and `Delete` buttons for those functions
In the case of errors with the backend API there are redirects back to the `/methods` route
This covers if the token is expired in the cookie or if there is a systemic issue with the backend
This error handling strategy can be reviewed at a later time for a more robust solution